### PR TITLE
fix: login/precheck api in non-ee variant

### DIFF
--- a/ee/query-service/app/api/auth.go
+++ b/ee/query-service/app/api/auth.go
@@ -107,7 +107,7 @@ func (ah *APIHandler) registerUser(w http.ResponseWriter, r *http.Request) {
 		RespondError(w, model.InternalError(basemodel.ErrSignupFailed{}), nil)
 	}
 
-	precheckResp := &model.PrecheckResponse{
+	precheckResp := &basemodel.PrecheckResponse{
 		SSO:    false,
 		IsUser: false,
 	}

--- a/ee/query-service/dao/interface.go
+++ b/ee/query-service/dao/interface.go
@@ -21,7 +21,6 @@ type ModelDao interface {
 	DB() *sqlx.DB
 
 	// auth methods
-	PrecheckLogin(ctx context.Context, email, sourceUrl string) (*model.PrecheckResponse, basemodel.BaseApiError)
 	CanUsePassword(ctx context.Context, email string) (bool, basemodel.BaseApiError)
 	PrepareSsoRedirect(ctx context.Context, redirectUri, email string) (redirectURL string, apierr basemodel.BaseApiError)
 	GetDomainFromSsoResponse(ctx context.Context, relayState *url.URL) (*model.OrgDomain, error)

--- a/ee/query-service/dao/sqlite/auth.go
+++ b/ee/query-service/dao/sqlite/auth.go
@@ -120,10 +120,10 @@ func (m *modelDao) CanUsePassword(ctx context.Context, email string) (bool, base
 
 // PrecheckLogin is called when the login or signup page is loaded
 // to check sso login is to be prompted
-func (m *modelDao) PrecheckLogin(ctx context.Context, email, sourceUrl string) (*model.PrecheckResponse, basemodel.BaseApiError) {
+func (m *modelDao) PrecheckLogin(ctx context.Context, email, sourceUrl string) (*basemodel.PrecheckResponse, basemodel.BaseApiError) {
 
 	// assume user is valid unless proven otherwise
-	resp := &model.PrecheckResponse{IsUser: true, CanSelfRegister: false}
+	resp := &basemodel.PrecheckResponse{IsUser: true, CanSelfRegister: false}
 
 	// check if email is a valid user
 	userPayload, baseApiErr := m.GetUserByEmail(ctx, email)

--- a/ee/query-service/model/auth.go
+++ b/ee/query-service/model/auth.go
@@ -4,18 +4,9 @@ import (
 	basemodel "go.signoz.io/signoz/pkg/query-service/model"
 )
 
-// PrecheckResponse contains login precheck response
-type PrecheckResponse struct {
-	SSO             bool   `json:"sso"`
-	SsoUrl          string `json:"ssoUrl"`
-	CanSelfRegister bool   `json:"canSelfRegister"`
-	IsUser          bool   `json:"isUser"`
-	SsoError        string `json:"ssoError"`
-}
-
 // GettableInvitation overrides base object and adds precheck into
 // response
 type GettableInvitation struct {
 	*basemodel.InvitationResponseObject
-	Precheck *PrecheckResponse `json:"precheck"`
+	Precheck *basemodel.PrecheckResponse `json:"precheck"`
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -388,6 +388,7 @@ func (aH *APIHandler) RegisterRoutes(router *mux.Router, am *AuthMiddleware) {
 
 	router.HandleFunc("/api/v1/register", am.OpenAccess(aH.registerUser)).Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/login", am.OpenAccess(aH.loginUser)).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/loginPrecheck", am.OpenAccess(aH.precheckLogin)).Methods(http.MethodGet)
 
 	router.HandleFunc("/api/v1/user", am.AdminAccess(aH.listUsers)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/user/{id}", am.SelfAccess(aH.getUser)).Methods(http.MethodGet)
@@ -1862,6 +1863,19 @@ func (aH *APIHandler) registerUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	aH.Respond(w, nil)
+}
+
+func (aH *APIHandler) precheckLogin(w http.ResponseWriter, r *http.Request) {
+
+	email := r.URL.Query().Get("email")
+	sourceUrl := r.URL.Query().Get("ref")
+
+	resp, apierr := aH.appDao.PrecheckLogin(context.Background(), email, sourceUrl)
+	if apierr != nil {
+		RespondError(w, apierr, resp)
+	}
+
+	aH.Respond(w, resp)
 }
 
 func (aH *APIHandler) loginUser(w http.ResponseWriter, r *http.Request) {

--- a/pkg/query-service/dao/interface.go
+++ b/pkg/query-service/dao/interface.go
@@ -34,6 +34,8 @@ type Queries interface {
 	GetUsersByGroup(ctx context.Context, groupId string) ([]model.UserPayload, *model.ApiError)
 
 	GetApdexSettings(ctx context.Context, services []string) ([]model.ApdexSettings, *model.ApiError)
+
+	PrecheckLogin(ctx context.Context, email, sourceUrl string) (*model.PrecheckResponse, model.BaseApiError)
 }
 
 type Mutations interface {

--- a/pkg/query-service/dao/sqlite/rbac.go
+++ b/pkg/query-service/dao/sqlite/rbac.go
@@ -597,3 +597,20 @@ func (mds *ModelDaoSqlite) UpdateUserFlags(ctx context.Context, userId string, f
 
 	return flags, nil
 }
+
+func (mds *ModelDaoSqlite) PrecheckLogin(ctx context.Context, email, sourceUrl string) (*model.PrecheckResponse, model.BaseApiError) {
+	// assume user is valid unless proven otherwise and assign default values for rest of the fields
+	resp := &model.PrecheckResponse{IsUser: true, CanSelfRegister: false, SSO: false, SsoUrl: "", SsoError: ""}
+
+	// check if email is a valid user
+	userPayload, baseApiErr := mds.GetUserByEmail(ctx, email)
+	if baseApiErr != nil {
+		return resp, baseApiErr
+	}
+
+	if userPayload == nil {
+		resp.IsUser = false
+	}
+
+	return resp, nil
+}

--- a/pkg/query-service/model/auth.go
+++ b/pkg/query-service/model/auth.go
@@ -32,6 +32,15 @@ type LoginRequest struct {
 	RefreshToken string `json:"refreshToken"`
 }
 
+// PrecheckResponse contains login precheck response
+type PrecheckResponse struct {
+	SSO             bool   `json:"sso"`
+	SsoUrl          string `json:"ssoUrl"`
+	CanSelfRegister bool   `json:"canSelfRegister"`
+	IsUser          bool   `json:"isUser"`
+	SsoError        string `json:"ssoError"`
+}
+
 type UserJwtObject struct {
 	AccessJwt        string `json:"accessJwt"`
 	AccessJwtExpiry  int64  `json:"accessJwtExpiry"`


### PR DESCRIPTION
Implemented login/precheck API in pkg/query-service, moved interfaces and struct definition to pkg which are then imported into the ee folder for use in the implementation present in that directory.